### PR TITLE
refactor(map decorator): make field config parameter optional

### DIFF
--- a/src/decorators/map.ts
+++ b/src/decorators/map.ts
@@ -89,7 +89,7 @@ const toData = (
  * Registers a new map with firestorm.
  * @param fieldConfig The field configuration
  */
-export default function (fieldConfig: IFieldMapConfig): Function {
+export default function (fieldConfig: IFieldMapConfig = {}): Function {
   return function (target: any, key: string): void {
     const type = Reflect.getMetadata('design:type', target, key);
     const field = FieldUtils.configure(


### PR DESCRIPTION
`@map()` decorator requires fieldConfig, while it can be omitted as in `@field()`, `@timestamp()`, `@geopoint()` decorators.