### PR TITLE
feat(query): add ability to pass property path array to where() and orderBy() methods

### DIFF
--- a/src/Collection.ts
+++ b/src/Collection.ts
@@ -197,11 +197,9 @@ class Collection <T extends Entity, P extends Entity> implements ICollection<T, 
    * Entry point for building queries.
    */
   public query(): Query<T> {
-    const fields = getRepository(this._Entity.prototype.constructor.name).fields;
     return new Query(
       this._Entity,
       this,
-      fields,
       this._native,
     );
   }

--- a/src/types/collection.types.ts
+++ b/src/types/collection.types.ts
@@ -9,8 +9,8 @@ export interface IEntity {
 }
 
 export interface IQuery <T extends IEntity> {
-  where(property: keyof T, op: firestore.WhereFilterOp, value: any): IQuery<T>;
-  orderBy(property: keyof T, sort?: firestore.OrderByDirection): IQuery<T>;
+  where(property: keyof T | [keyof T, ...string[]], op: firestore.WhereFilterOp, value: any): IQuery<T>;
+  orderBy(property: keyof T | [keyof T, ...string[]], sort?: firestore.OrderByDirection): IQuery<T>;
   limit(amount: number): IQuery<T>;
   startAt(...fieldValues: any[]): IQuery<T>;
   startAfter(...fieldValues: any[]): Query<T>;


### PR DESCRIPTION
Currently it is not possible to make queries for nested object fields:
```typescript
class Comment extends Entity {
  ...
  @field({ name: 'by' })
  by!: string;
}

@rootCollection({ name: 'posts' })
class Post extends Entity {
  ...
  @field({ name: 'pinnedComment' })
  pinnedComment!: Comment;
}
...
Collection(Post).query().where('pinnedComment.by', '==', 'userId').get();
```
Error: `error TS2345: Argument of type '"pinnedComment.by"' is not assignable to parameter of type '... | "by" | "ref" | "toData"'.`
The proposal is to optionally pass an array of properties as a path:
```typescript
Collection(Post).query().where(['pinnedComment', 'by'], '==', 'userId').get();
```